### PR TITLE
Add styled components properly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true }]]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "devDependencies": {
         "@types/node": "^14.14.6",
         "@types/react": "^16.9.56",
+        "babel-plugin-styled-components": "^1.12.0",
         "typescript": "^4.0.5"
     }
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,12 +5,33 @@ import Document, {
     Main,
     NextScript,
 } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
 class MyDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
-        const initialProps = await Document.getInitialProps(ctx);
+        const sheet = new ServerStyleSheet();
+        const originalRenderPage = ctx.renderPage;
 
-        return initialProps;
+        try {
+            ctx.renderPage = () =>
+                originalRenderPage({
+                    enhanceApp: App => props =>
+                        sheet.collectStyles(<App {...props} />),
+                });
+
+            const initialProps = await Document.getInitialProps(ctx);
+            return {
+                ...initialProps,
+                styles: (
+                    <>
+                        {initialProps.styles}
+                        {sheet.getStyleElement()}
+                    </>
+                ),
+            };
+        } finally {
+            sheet.seal();
+        }
     }
 
     render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,6 +1565,16 @@ babel-plugin-dynamic-import-node@^2.3.3:
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
 
+babel-plugin-styled-components@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
+  integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
All Credit goes to [Server side rendering styled-components with NextJS]( https://medium.com/swlh/server-side-rendering-styled-components-with-nextjs-1db1353e915e)

I just did this on my own site because I was having the same styled issue problem you were. 

This should hopefully do two things.

1. Stop errors from breaking your css when you reload the page
2. Enable the server to pre-render css so you can disable javascript and the css will render. 

![image](https://user-images.githubusercontent.com/10930659/118342813-00617c80-b51d-11eb-8f4f-5c28e890a79e.png)
